### PR TITLE
Adjust expand logic to specify subRowHeight as opposed to cellHeight

### DIFF
--- a/examples/ExpandedExample.js
+++ b/examples/ExpandedExample.js
@@ -26,9 +26,17 @@ class ExpandedExample extends React.Component {
 
   _handleCollapseClick(rowIndex) {
     let {collapsedRows} = this.state;
-    collapsedRows.has(rowIndex) ? collapsedRows.delete(rowIndex) : collapsedRows.add(rowIndex);
+
+    let scrollToRow = rowIndex;
+    if (collapsedRows.has(rowIndex)) {
+      collapsedRows.delete(rowIndex);
+      scrollToRow = null;
+    } else {
+      collapsedRows.add(rowIndex);
+    }
+
     this.setState({
-      scrollToRow: rowIndex,
+      scrollToRow: scrollToRow,
       collapsedRows: collapsedRows
     });
   }
@@ -37,11 +45,22 @@ class ExpandedExample extends React.Component {
     return this.state.collapsedRows.has(index) ? 80 : 0;
   }
 
-  _rowExpandedGetter({rowIndex}) {
+  _rowExpandedGetter({rowIndex, width, height}) {
     if (!this.state.collapsedRows.has(rowIndex)) {
       return null;
     }
-    return <div className={css(styles.expandStyles)}>expanded content</div>;
+
+    const style = {
+      height: height,
+      width: width - 2,
+    };
+    return (
+      <div style={style}>
+        <div className={css(styles.expandStyles)}>
+            expanded content
+        </div>
+      </div>
+    );
   }
 
   render() {

--- a/examples/ExpandedExample.js
+++ b/examples/ExpandedExample.js
@@ -20,8 +20,7 @@ class ExpandedExample extends React.Component {
     }
 
     this._handleCollapseClick = this._handleCollapseClick.bind(this);
-    this._rowHeightGetter = this._rowHeightGetter.bind(this);
-    this._cellHeightGetter = this._cellHeightGetter.bind(this);
+    this._subRowHeightGetter = this._subRowHeightGetter.bind(this);
     this._rowExpandedGetter = this._rowExpandedGetter.bind(this);
   }
 
@@ -34,18 +33,15 @@ class ExpandedExample extends React.Component {
     });
   }
 
-  _rowHeightGetter(index) {
-    let cellHeight = this._cellHeightGetter(index)
-    return this.state.collapsedRows.has(index) ? cellHeight + 80 : cellHeight;
-  }
-
-  _cellHeightGetter(index) {
-    return this.state.collapsedRows.has(index) ? 51 : 50;
+  _subRowHeightGetter(index) {
+    return this.state.collapsedRows.has(index) ? 80 : 0;
   }
 
   _rowExpandedGetter({rowIndex}) {
-    if (!this.state.collapsedRows.has(rowIndex)) return null
-    return <div className={css(styles.expandStyles)}>expanded content</div>
+    if (!this.state.collapsedRows.has(rowIndex)) {
+      return null;
+    }
+    return <div className={css(styles.expandStyles)}>expanded content</div>;
   }
 
   render() {
@@ -57,8 +53,7 @@ class ExpandedExample extends React.Component {
           scrollToRow={scrollToRow}
           rowHeight={50}
           rowsCount={dataList.getSize()}
-          rowHeightGetter={this._rowHeightGetter}
-          cellHeightGetter={this._cellHeightGetter}
+          subRowHeightGetter={this._subRowHeightGetter}
           rowExpanded={this._rowExpandedGetter}
           headerHeight={50}
           width={1000}

--- a/site/Constants.js
+++ b/site/Constants.js
@@ -70,7 +70,7 @@ exports.ExamplePages = {
     location: 'example-expanded-rows.html',
     fileName: 'ExpandedExample.js',
     title: 'Expanded rows',
-    description: 'A table example that will let the user expanded individual rows',
+    description: 'A table example that will let the user expand individual rows',
   },
   HIDE_COLUMN_EXAMPLE: {
     location: 'example-collapse.html',

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -184,16 +184,16 @@ var FixedDataTable = createReactClass({
     rowHeightGetter: PropTypes.func,
 
     /**
-     * Pixel height of cells unless `cellHeightGetter` is specified and returns
-     * different value.
+     * Pixel height of sub-row unless `subRowHeightGetter` is specified and returns
+     * different value.  Defaults to 0 and no sub-row being displayed.
      */
-    cellHeight: PropTypes.number,
+    subRowHeight: PropTypes.number,
 
     /**
-     * If specified, `cellHeightGetter(index)` is called for each row and the
-     * returned value overrides `cellHeight` for particular row.
+     * If specified, `subRowHeightGetter(index)` is called for each row and the
+     * returned value overrides `subRowHeight` for particular row.
      */
-    cellHeightGetter: PropTypes.func,
+    subRowHeightGetter: PropTypes.func,
 
    /**
     * The row expanded for table row.
@@ -388,7 +388,9 @@ var FixedDataTable = createReactClass({
       props.rowsCount,
       props.rowHeight,
       viewportHeight,
-      props.rowHeightGetter
+      props.rowHeightGetter,
+      props.subRowHeight,
+      props.subRowHeightGetter,
     );
 
     this._didScrollStop = debounceCore(this._didScrollStop, 200, this);
@@ -721,8 +723,8 @@ var FixedDataTable = createReactClass({
         rowsCount={state.rowsCount}
         rowGetter={state.rowGetter}
         rowHeightGetter={state.rowHeightGetter}
-        cellHeight={state.cellHeight}
-        cellHeightGetter={state.cellHeightGetter}
+        subRowHeight={state.subRowHeight}
+        subRowHeightGetter={state.subRowHeightGetter}
         rowExpanded={state.rowExpanded}
         rowKeyGetter={state.rowKeyGetter}
         scrollLeft={state.scrollX}
@@ -988,14 +990,21 @@ var FixedDataTable = createReactClass({
         props.rowsCount,
         props.rowHeight,
         viewportHeight,
-        props.rowHeightGetter
+        props.rowHeightGetter,
+        props.subRowHeight,
+        props.subRowHeightGetter,
       );
       scrollState = this._scrollHelper.scrollToRow(firstRowIndex, firstRowOffset);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;
       scrollY = scrollState.position;
-    } else if (oldState && props.rowHeightGetter !== oldState.rowHeightGetter) {
-      this._scrollHelper.setRowHeightGetter(props.rowHeightGetter);
+    } else if (oldState) {
+      if (props.rowHeightGetter !== oldState.rowHeightGetter) {
+        this._scrollHelper.setRowHeightGetter(props.rowHeightGetter);
+      }
+      if (props.subRowHeightGetter !== oldState.subRowHeightGetter) {
+        this._scrollHelper.setSubRowHeightGetter(props.subRowHeightGetter);
+      }
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;

--- a/src/FixedDataTable.js
+++ b/src/FixedDataTable.js
@@ -1008,8 +1008,7 @@ var FixedDataTable = createReactClass({
     }
 
     var lastScrollToRow  = oldState ? oldState.scrollToRow : undefined;
-    var rowHeightChanged = props.scrollToRow != null ? this._scrollHelper.getRowHeightChanged(props.scrollToRow) : 0
-    if (props.scrollToRow != null && (props.scrollToRow !== lastScrollToRow || rowHeightChanged !== 0 || viewportHeight !== oldViewportHeight)) {
+    if (props.scrollToRow != null && (props.scrollToRow !== lastScrollToRow || viewportHeight !== oldViewportHeight)) {
       scrollState = this._scrollHelper.scrollRowIntoView(props.scrollToRow);
       firstRowIndex = scrollState.index;
       firstRowOffset = scrollState.offset;

--- a/src/FixedDataTableBufferedRows.js
+++ b/src/FixedDataTableBufferedRows.js
@@ -40,8 +40,8 @@ var FixedDataTableBufferedRows = createReactClass({
     rowClassNameGetter: PropTypes.func,
     rowsCount: PropTypes.number.isRequired,
     rowHeightGetter: PropTypes.func,
-    cellHeight: PropTypes.number,
-    cellHeightGetter: PropTypes.func,
+    subRowHeight: PropTypes.number,
+    subRowHeightGetter: PropTypes.func,
     rowExpanded: PropTypes.oneOfType([
       PropTypes.element,
       PropTypes.func,
@@ -147,7 +147,7 @@ var FixedDataTableBufferedRows = createReactClass({
     for (var i = 0; i < rowsToRender.length; ++i) {
       var rowIndex = rowsToRender[i];
       var currentRowHeight = this._getRowHeight(rowIndex);
-      var currentRowCellHeight = this._getCellHeight(rowIndex);
+      var currentSubRowHeight = this._getSubRowHeight(rowIndex);
       var rowOffsetTop = baseOffsetTop + rowPositions[rowIndex];
       var rowKey = props.rowKeyGetter ? props.rowKeyGetter(rowIndex) : i;
 
@@ -161,7 +161,7 @@ var FixedDataTableBufferedRows = createReactClass({
           index={rowIndex}
           width={props.width}
           height={currentRowHeight}
-          cellHeight={currentRowCellHeight || currentRowHeight}
+          subRowHeight={currentSubRowHeight}
           rowExpanded={props.rowExpanded}
           scrollLeft={Math.round(props.scrollLeft)}
           offsetTop={Math.round(rowOffsetTop)}
@@ -192,10 +192,10 @@ var FixedDataTableBufferedRows = createReactClass({
       this.props.defaultRowHeight;
   },
 
-  _getCellHeight(/*number*/ index) /*number*/ {
-    return this.props.cellHeightGetter ?
-      this.props.cellHeightGetter(index) :
-      this.props.cellHeight;
+  _getSubRowHeight(/*number*/ index) /*number*/ {
+    return this.props.subRowHeightGetter ?
+      this.props.subRowHeightGetter(index) :
+      this.props.subRowHeight;
   },
 });
 

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -41,9 +41,9 @@ class FixedDataTableRowImpl extends React.Component {
     height: PropTypes.number.isRequired,
 
     /**
-     * Height of the row cell.
+     * Height of the content to be displayed below the row.
      */
-    cellHeight: PropTypes.number,
+    subRowHeight: PropTypes.number,
 
     /**
      * the row expanded.
@@ -122,11 +122,11 @@ class FixedDataTableRowImpl extends React.Component {
   };
 
   render() /*object*/ {
+    var subRowHeight = this.props.subRowHeight || 0;
     var style = {
       width: this.props.width,
-      height: this.props.height,
+      height: this.props.height + subRowHeight,
     };
-    var cellHeight = this.props.cellHeight || this.props.height
     var className = cx({
       'fixedDataTableRowLayout/main': true,
       'public/fixedDataTableRow/main': true,
@@ -139,7 +139,7 @@ class FixedDataTableRowImpl extends React.Component {
       <FixedDataTableCellGroup
         key="fixed_cells"
         isScrolling={this.props.isScrolling}
-        height={cellHeight}
+        height={this.props.height}
         left={0}
         width={fixedColumnsWidth}
         zIndex={2}
@@ -150,7 +150,7 @@ class FixedDataTableRowImpl extends React.Component {
         onColumnReorderEnd={this.props.onColumnReorderEnd}
         isColumnReordering={this.props.isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
-        rowHeight={cellHeight}
+        rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
     var columnsLeftShadow = this._renderColumnsLeftShadow(fixedColumnsWidth);
@@ -158,7 +158,7 @@ class FixedDataTableRowImpl extends React.Component {
       <FixedDataTableCellGroup
         key="scrollable_cells"
         isScrolling={this.props.isScrolling}
-        height={cellHeight}
+        height={this.props.height}
         left={this.props.scrollLeft}
         offsetLeft={fixedColumnsWidth}
         width={this.props.width - fixedColumnsWidth}
@@ -170,15 +170,15 @@ class FixedDataTableRowImpl extends React.Component {
         onColumnReorderEnd={this.props.onColumnReorderEnd}
         isColumnReordering={this.props.isColumnReordering}
         columnReorderingData={this.props.columnReorderingData}
-        rowHeight={cellHeight}
+        rowHeight={this.props.height}
         rowIndex={this.props.index}
       />;
     var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
     var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);
     var rowExpandedStyle = {
-      top: cellHeight,
+      top: this.props.height,
       width: this.props.width - /* borderWidth */ 2,
-      height: this.props.height - this.props.cellHeight,
+      height: subRowHeight,
       zIndex: 2
     }
     var rowExpanded = this._getRowExpanded(rowExpandedStyle)

--- a/src/FixedDataTableRow.js
+++ b/src/FixedDataTableRow.js
@@ -175,13 +175,12 @@ class FixedDataTableRowImpl extends React.Component {
       />;
     var scrollableColumnsWidth = this._getColumnsWidth(this.props.scrollableColumns);
     var columnsRightShadow = this._renderColumnsRightShadow(fixedColumnsWidth + scrollableColumnsWidth);
+    var rowExpanded = this._getRowExpanded(subRowHeight);
     var rowExpandedStyle = {
-      top: this.props.height,
-      width: this.props.width - /* borderWidth */ 2,
       height: subRowHeight,
-      zIndex: 2
-    }
-    var rowExpanded = this._getRowExpanded(rowExpandedStyle)
+      top: this.props.height,
+      width: this.props.width,
+    };
 
     return (
       <div
@@ -215,12 +214,12 @@ class FixedDataTableRowImpl extends React.Component {
     return width;
   };
 
-  _getRowExpanded = (/*object*/ rowExpandedStyle) => /*?object*/ {
+  _getRowExpanded = (/*number*/ subRowHeight) => /*?object*/ {
     if (this.props.rowExpanded) {
       var rowExpandedProps = {
         rowIndex: this.props.index,
-        height: rowExpandedStyle.width,
-        width: rowExpandedStyle.height
+        height: subRowHeight,
+        width: this.props.width,
       };
 
       var rowExpanded;

--- a/src/FixedDataTableScrollHelper.js
+++ b/src/FixedDataTableScrollHelper.js
@@ -282,6 +282,7 @@ class FixedDataTableScrollHelper {
    */
   scrollRowIntoView(/*number*/ rowIndex) /*object*/ {
     rowIndex = clamp(rowIndex, 0, Math.max(this._rowCount - 1, 0));
+    this._updateRowHeight(rowIndex);
     var rowBegin = this._rowOffsets.sumUntil(rowIndex);
     var rowEnd = rowBegin + this._storedHeights[rowIndex];
     if (rowBegin < this._position) {

--- a/src/FixedDataTableScrollHelper.js
+++ b/src/FixedDataTableScrollHelper.js
@@ -28,20 +28,29 @@ class FixedDataTableScrollHelper {
     /*number*/ rowCount,
     /*number*/ defaultRowHeight,
     /*number*/ viewportHeight,
-    /*?function*/ rowHeightGetter
+    /*?function*/ rowHeightGetter,
+    /*number*/ defaultSubRowHeight = 0,
+    /*?function*/ subRowHeightGetter,
   ) {
-    this._rowOffsets = PrefixIntervalTree.uniform(rowCount, defaultRowHeight);
+    const defaultFullRowHeight = defaultRowHeight + defaultSubRowHeight;
+    this._rowOffsets = PrefixIntervalTree.uniform(rowCount, defaultFullRowHeight);
     this._storedHeights = new Array(rowCount);
     for (var i = 0; i < rowCount; ++i) {
-      this._storedHeights[i] = defaultRowHeight;
+      this._storedHeights[i] = defaultFullRowHeight;
     }
     this._rowCount = rowCount;
     this._position = 0;
-    this._contentHeight = rowCount * defaultRowHeight;
-    this._defaultRowHeight = defaultRowHeight;
-    this._rowHeightGetter = rowHeightGetter ?
-      rowHeightGetter :
-      () => defaultRowHeight;
+    this._contentHeight = rowCount * defaultFullRowHeight;
+
+    this._rowHeightGetter = rowHeightGetter;
+    this._subRowHeightGetter = subRowHeightGetter;
+    this._fullRowHeightGetter = (rowIdx) => {
+      const rowHeight = this._rowHeightGetter ? this._rowHeightGetter(rowIdx) :
+        defaultRowHeight;
+      const subRowHeight = this._subRowHeightGetter ? this._subRowHeightGetter(rowIdx) :
+        defaultSubRowHeight;
+      return rowHeight + subRowHeight;
+    };
     this._viewportHeight = viewportHeight;
     this.scrollRowIntoView = this.scrollRowIntoView.bind(this);
     this.setViewportHeight = this.setViewportHeight.bind(this);
@@ -49,6 +58,7 @@ class FixedDataTableScrollHelper {
     this.scrollTo = this.scrollTo.bind(this);
     this.scrollToRow = this.scrollToRow.bind(this);
     this.setRowHeightGetter = this.setRowHeightGetter.bind(this);
+    this.setSubRowHeightGetter = this.setSubRowHeightGetter.bind(this);
     this.getContentHeight = this.getContentHeight.bind(this);
     this.getRowPosition = this.getRowPosition.bind(this);
 
@@ -57,6 +67,10 @@ class FixedDataTableScrollHelper {
 
   setRowHeightGetter(/*function*/ rowHeightGetter) {
     this._rowHeightGetter = rowHeightGetter;
+  }
+
+  setSubRowHeightGetter(/*function*/ subRowHeightGetter) {
+    this._subRowHeightGetter = subRowHeightGetter;
   }
 
   setViewportHeight(/*number*/ viewportHeight) {
@@ -93,7 +107,7 @@ class FixedDataTableScrollHelper {
     if (rowIndex < 0 || rowIndex >= this._rowCount) {
       return 0;
     }
-    var newHeight = this._rowHeightGetter(rowIndex);
+    var newHeight = this._fullRowHeightGetter(rowIndex);
     if (newHeight !== this._storedHeights[rowIndex]) {
       var change = newHeight - this._storedHeights[rowIndex];
       this._rowOffsets.set(rowIndex, newHeight);


### PR DESCRIPTION
Here are some changes to help with what I asked on the CR.  Can you look them over and merge to your branch when ready / have tested this fits your needs?

## Description
This keeps rowHeight as the height of the FDT row and subRowHeight as the expand content.
Also additional fixes to move configurability of style into example / user space

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
